### PR TITLE
fix: support for '@as []' on bindings get

### DIFF
--- a/command.sh
+++ b/command.sh
@@ -35,7 +35,7 @@ BASE_PATH="/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings"
 NEW_PATH="$BASE_PATH/$SCHEMA_NAME/"
 
 # Retrieve the current list of custom shortcuts from gsettings
-CURRENT_LIST=$(gsettings get org.gnome.settings-daemon.plugins.media-keys custom-keybindings)
+CURRENT_LIST=$(gsettings get org.gnome.settings-daemon.plugins.media-keys custom-keybindings | sed 's/^@as //')
 
 # Process the list string by removing brackets for easier manipulation
 CURRENT_LIST="${CURRENT_LIST#[}"


### PR DESCRIPTION
With my version of `gsettings 2.80.0` command `gsettings get org.gnome.settings-daemon.plugins.media-keys custom-keybindings` returns `@as []`. To fix further processing, we need to strip `@as `, which I propose to do with simple `sed`.

This `sed` addition does nothing if command returns `[]`, so the old logic should work as before.